### PR TITLE
Bump version

### DIFF
--- a/plugin.ini
+++ b/plugin.ini
@@ -1,6 +1,6 @@
 [Plugin description]
 name =              "Facebook"
-version =           0.1
+version =           0.2
 author =            "Known"
 author_email =      "hello@withknown.com"
 author_url =        "https://withknown.com/"


### PR DESCRIPTION
The genesis of this is that I had a copy of the plugin that identified itself as "0.1" but it was _way_ older than what's on master now.  It would be nice to see this update in the Known "Plugin" config.

Upgrading to the latest on master fixed an issue I was having with the OAuth callback.